### PR TITLE
NUI-638 update standard profile in Meahana and dev-tool for Align API with XDM and drop S7 shortcut names (width vs. wid)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ typings/
 
 # Yarn Integrity file
 .yarn-integrity
+package-lock.json
 
 # dotenv environment variables file
 .env

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -42,14 +42,14 @@ const DEFAULT_RENDITIONS_TEXT  = JSON.stringify({
         {
             "name": "rendition.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "rendition.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         }
     ]
 }, undefined, 4);

--- a/client/src/components/TextEditor/ChangeAssetComputeProfileButton.jsx
+++ b/client/src/components/TextEditor/ChangeAssetComputeProfileButton.jsx
@@ -33,26 +33,26 @@ const STANDARD_AEM_PROFILE = JSON.stringify({
         {
             "name": "cq5dam.thumbnail.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "cq5dam.thumbnail.140.100.png",
             "fmt": "png",
-            "wid": 140,
-            "hei": 100
+            "width": 140,
+            "height": 100
         },
         {
             "name": "cq5dam.thumbnail.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         },
         {
             "name": "cq5dam.web.1280.1280.png",
             "fmt": "jpg",
-            "wid": 1280,
-            "hei": 1280
+            "width": 1280,
+            "height": 1280
         }
     ]
 }, undefined, 4);
@@ -70,14 +70,14 @@ const SIMPLE_REQUEST = JSON.stringify({
         {
             "name": "rendition.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "rendition.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         }
     ]
 }, undefined, 4);

--- a/client/src/components/TextEditor/Editor.jsx
+++ b/client/src/components/TextEditor/Editor.jsx
@@ -31,14 +31,14 @@ const DEFAULT_RENDITIONS_TEXT  = JSON.stringify({
         {
             "name": "rendition.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "rendition.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         }
     ]
 }, undefined, 4);

--- a/client/src/components/TextEditor/__tests__/ChangeAssetComputeProfileButton.test.js
+++ b/client/src/components/TextEditor/__tests__/ChangeAssetComputeProfileButton.test.js
@@ -30,26 +30,26 @@ const STANDARD_AEM_PROFILE = {
         {
             "name": "cq5dam.thumbnail.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "cq5dam.thumbnail.140.100.png",
             "fmt": "png",
-            "wid": 140,
-            "hei": 100
+            "width": 140,
+            "height": 100
         },
         {
             "name": "cq5dam.thumbnail.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         },
         {
             "name": "cq5dam.web.1280.1280.png",
             "fmt": "jpg",
-            "wid": 1280,
-            "hei": 1280
+            "width": 1280,
+            "height": 1280
         }
     ]
 }
@@ -73,7 +73,7 @@ describe('ChangeAssetComputeProfileButton', () => {
     });
 
     it('ChangeAssetComputeProfileButton -> Choose Standard AEM Profile', () => {
-        const wrapper = shallow(<ChangeAssetComputeProfileButton onChangeProfile={(v) => { 
+        const wrapper = shallow(<ChangeAssetComputeProfileButton onChangeProfile={(v) => {
             expect(v).toEqual(STANDARD_AEM_PROFILE);
         }}/>);
 

--- a/client/src/components/TextEditor/__tests__/Editor.test.js
+++ b/client/src/components/TextEditor/__tests__/Editor.test.js
@@ -30,14 +30,14 @@ const DEFAULT_RENDITIONS_TEXT  = {
         {
             "name": "rendition.48.48.png",
             "fmt": "png",
-            "wid": 48,
-            "hei": 48
+            "width": 48,
+            "height": 48
         },
         {
             "name": "rendition.319.319.png",
             "fmt": "png",
-            "wid": 319,
-            "hei": 319
+            "width": 319,
+            "height": 319
         }
     ]
 };
@@ -74,7 +74,7 @@ describe('Editor', () => {
     it('Displays action urls as renditions after mounting', () => {
         const workerURLs = {
             'worker-example': 'https://namespace.adobeioruntime.net/api/v1/web/@adobe/asset-compute-devtool-1.0.1/worker-example',
-            generic: 'https://namespace.adobeioruntime.net/api/v1/web/@adobe/asset-compute-devtool-1.0.1/generic' 
+            generic: 'https://namespace.adobeioruntime.net/api/v1/web/@adobe/asset-compute-devtool-1.0.1/generic'
         };
         fetch.mockResponseOnce(JSON.stringify(workerURLs))
         mount(<Editor onChange={(v) => {expect(JSON.parse(v)).toEqual(CUSTOM_WORKER_RENDITIONS)}} devToolToken={DEVTOOL_TOKEN} />)


### PR DESCRIPTION
## Description

Updated `hei` to `height`
Updated `wid` to `width`
Added `package-lock.json` to .gitignore's per yarn's warning

Fixes # [NUI-638 update standard profile in Meahana and dev-tool for Align API with XDM and drop S7 shortcut names (width vs. wid)](https://jira.corp.adobe.com/browse/NUI-638)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
