### PR TITLE
Travis CI: add sizewatcher

### DIFF
--- a/.sizewatcher.yml
+++ b/.sizewatcher.yml
@@ -1,0 +1,9 @@
+comparators:
+  node_modules:
+    dir:
+      - "client"
+      - "server"
+  npm_package:
+    dir:
+      - "client"
+      - "server"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,5 @@ after_success:
   - npm run report-coverage
 
 after_script:
+  - pwd
   - DEBUG=sizewatcher npx @adobe/sizewatcher@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ after_success:
   - npm run report-coverage
 
 after_script:
-  - npx @adobe/sizewatcher
+  - DEBUG=sizewatcher npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,4 @@ after_success:
 
 after_script:
   - cd $TRAVIS_BUILD_DIR
-  - pwd
-  - DEBUG=sizewatcher npx @adobe/sizewatcher@latest
+  - npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ script:
       fi
 after_success:
   - npm run report-coverage
+
+after_script:
+  - npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ after_success:
   - npm run report-coverage
 
 after_script:
-  - DEBUG=sizewatcher npx @adobe/sizewatcher
+  - DEBUG=sizewatcher npx @adobe/sizewatcher@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,6 @@ after_success:
   - npm run report-coverage
 
 after_script:
+  - cd $TRAVIS_BUILD_DIR
   - pwd
   - DEBUG=sizewatcher npx @adobe/sizewatcher@latest


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).