### PR TITLE
Add releaserc for semantic release

### DIFF
--- a/server/.releaserc
+++ b/server/.releaserc
@@ -1,0 +1,35 @@
+{
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "eslint",
+      "releaseRules": [
+      {
+        "subject": "*",
+        "release": false
+      },
+      {
+        "subject": "FEATURE-RELEASE:*",
+        "release": "minor"
+      },
+      {
+        "subject": "BUGFIX-RELEASE:*",
+        "release": "patch"
+      },
+      {
+        "subject": "BREAKING-RELEASE:*",
+        "release": "major"
+      }
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "eslint"
+    }],
+    ["@semantic-release/npm"],
+    ["@semantic-release/git", {
+      "preset": "eslint",
+      "assets": ["package.json", "package-lock.json"],
+      "message": " [ci skip] no-release: version number update"
+    }],
+    ["@semantic-release/github"]
+  ]
+}

--- a/server/.releaserc
+++ b/server/.releaserc
@@ -27,7 +27,7 @@
     ["@semantic-release/npm"],
     ["@semantic-release/git", {
       "preset": "eslint",
-      "assets": ["package.json", "package-lock.json"],
+      "assets": ["package.json", "yarn.lock"],
       "message": " [ci skip] no-release: version number update"
     }],
     ["@semantic-release/github"]


### PR DESCRIPTION
## Description

The release failed because there was no `.releaserc` so it did not recognize `BUGFIX-RELEASE` as a signal to release:
https://github.com/adobe/asset-compute-devtool/runs/1711449941?check_suite_focus=true#step:5:507
```
[10:11:55 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: BUGFIX-RELEASE: update dependencies (#47)

* BUGFIX-RELEASE: update dependencies

* update yarn lock

* update dependencies on client
[10:11:55 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
```

I believe it should be in the /server folder since that is where semantic-release is run
Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
